### PR TITLE
Update TLDR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ git clone https://github.com/flatland-association/flatland-rl.git
 cd flatland-rl
 python -m pip install -r requirements.txt -r requirements-dev.txt
 
-set PYTHONPATH=C:\<currentpath>
+$env:PYTHONPATH=$pwd
 python -m jupyter notebook
 
 # open browser http://127.0.0.1:8888/notebooks/notebooks/flatland_animate.ipynb


### PR DESCRIPTION
Run notebook as python module. According to https://jupyter.org/install#jupyter-notebook, this should be necessary.
Should fix https://github.com/flatland-association/flatland-workshop-2024/pull/2#issuecomment-2483503347 if path is not updated correctly.